### PR TITLE
:wrench: Disable Dependency Pinning

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,7 +4,7 @@
   "major": {
     "automerge": false
   },
-  "rangeStrategy": "pin",
+  "rangeStrategy": "auto",
   "packageRules": [
     {
       "matchUpdateTypes": ["patch"],


### PR DESCRIPTION
This pull request makes a minor configuration update to the Renovate bot settings. The change adjusts how dependency versions are managed.

* Renovate configuration: Changed the `rangeStrategy` setting in `.github/renovate.json` from `"pin"` to `"auto"`, allowing automatic updates to dependency ranges rather than pinning to specific versions.